### PR TITLE
Added general purpose volumes ('gp2')

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## v0.4.1
+- Added volume_type configuration, which enables the possibility to choose from
+  'io1', 'standard' and now, also, 'gp2'.
+
 ## v0.4.0
 - Resolve problems in ubuntu distributions.
 ## v0.4.0

--- a/README.md
+++ b/README.md
@@ -80,6 +80,25 @@ Create a 10GB volume with 1000 provisioned iops, format it with XFS, and mount i
 
 `mount_options` are optional and will default to `noatime,nobootwait` on all platforms except Amazon linux, where they will default to `noatime`.
 
+Now, from v0.4.1, you can also provision general purpose SSD volumes ('gp2'), with the new `volume_type` option:
+```ruby
+{
+  :ebs => {
+    :volumes => {
+      '/data' => {
+        :size => 10,
+        :volume_type => 'gp2',
+        :fstype => 'xfs',
+        :mount_options => 'noatime',
+        :delete_on_termination => true
+      }
+    }
+  }
+}
+```
+
+By default, it will take 'standard'.
+
 ## Credentials
 
 Expects a `credentials` databag with an `aws` item that contains `aws_access_key_id` and `aws_secret_access_key`.

--- a/recipes/volumes.rb
+++ b/recipes/volumes.rb
@@ -29,7 +29,7 @@ node[:ebs][:volumes].each do |mount_point, options|
       device device
       availability_zone node[:ec2][:placement_availability_zone]
       delete_on_termination options[:delete_on_termination] ? options[:delete_on_termination] : true
-      volume_type options[:piops] ? 'io1' : 'standard'
+      volume_type options[:volume_type] ? options[:volume_type] : 'standard'
       piops options[:piops]
       action :nothing
     end

--- a/recipes/volumes.rb
+++ b/recipes/volumes.rb
@@ -29,7 +29,7 @@ node[:ebs][:volumes].each do |mount_point, options|
       device device
       availability_zone node[:ec2][:placement_availability_zone]
       delete_on_termination options[:delete_on_termination] ? options[:delete_on_termination] : true
-      volume_type options[:volume_type] ? options[:volume_type] : 'standard'
+      volume_type options[:piops] ? 'io1' : options[:volume_type] ? options[:volume_type] : 'standard'
       piops options[:piops]
       action :nothing
     end


### PR DESCRIPTION
Added volume_type configuration, which enables the possibility to choose from 'io1', 'standard' and now, also, 'gp2'.
